### PR TITLE
Feature/factory girl install

### DIFF
--- a/lib/generators/harbourmaster/install/install_generator.rb
+++ b/lib/generators/harbourmaster/install/install_generator.rb
@@ -23,5 +23,19 @@ module Harbourmaster
     def initialize_apitome
       generate "apitome:install"
     end
+
+    def use_factory_girl_syntax
+      # Remove these two lines if they're already there
+      gsub_file 'spec/rails_helper.rb', /^\s\# Use FactoryGirl shortcuts/, ""
+      gsub_file 'spec/rails_helper.rb', /\s*config.include FactoryGirl::Syntax::Methods\s*/, ""
+      # Then add them so we know that they are there
+      inject_into_file 'spec/rails_helper.rb', after: /RSpec.configure do\s*.*\n/ do
+        <<-RUBY
+  # Use FactoryGirl shortcuts
+  config.include FactoryGirl::Syntax::Methods
+
+        RUBY
+      end
+    end
   end
 end

--- a/lib/generators/harbourmaster/install/templates/rspec_api_documentation.rb
+++ b/lib/generators/harbourmaster/install/templates/rspec_api_documentation.rb
@@ -43,7 +43,7 @@ RspecApiDocumentation.configure do |config|
 
   # Redefine what method the DSL thinks is the client
   # This is useful if you need to `let` your own client, most likely a model.
-  config.client_method = :client
+  # config.client_method = :client
 
   # Change the IODocs writer protocol
   config.io_docs_protocol = "http"


### PR DESCRIPTION
Sometimes, new Rails apps were erroring when running the acceptance tests generated by Harbourmaster because:

1) The Factory Girl Syntax (`create` vs `FactoryGirl.create`) is used, so needs to be included in the `rails_helper`

2) The `client` method should be automatically defined, rather than defined in the  `rspec_api_documentation` installer (I don't know why, but, when this line is commented out, it works, with the line left in, it doesn't!)

This PR fixes these two issues by changing the `rspec_api_documentation` template and ensuring that the Factory Girl syntax is included in the `rails_helper` config.